### PR TITLE
disable android's chrome pull-down-to-refresh feature

### DIFF
--- a/src/styles/_game.scss
+++ b/src/styles/_game.scss
@@ -1,3 +1,7 @@
+body {
+    overflow-y: hidden;
+}
+
 .wrapper {
     background-image: url('./pics/background.png');
     background-size: cover;


### PR DESCRIPTION
this pull request prevents page refresh on pull down (very annoying when game state is lost with accidental refresh)

see [this](https://www.youtube.com/watch?v=AXOxesks-_g) video
[discussion ](https://stackoverflow.com/questions/29008194/disabling-androids-chrome-pull-down-to-refresh-feature)about this on stackoverflow
